### PR TITLE
Fix in recursive thenable

### DIFF
--- a/JavaScript/9-recursive.js
+++ b/JavaScript/9-recursive.js
@@ -18,10 +18,14 @@ class Thenable {
     const onSuccess = this.onSuccess;
     if (onSuccess) {
       const next = onSuccess(value);
-      if (next && next.then) {
-        next.then(value => {
-          this.next.resolve(value);
-        });
+      if (next) {
+        if (next.then) {
+          next.then(value => {
+            this.next.resolve(value);
+          });
+        } else {
+          this.next.resolve(next);
+        }
       }
     }
   }

--- a/JavaScript/9-recursive.js
+++ b/JavaScript/9-recursive.js
@@ -53,6 +53,10 @@ readFile('1-contract.js')
   })
   .then(data => {
     console.dir({ file3: data.length });
+    return 'I will be printed by callback in the next then';
+  })
+  .then(data => {
+    console.dir({ text: data });
   })
   .then(() => {
     console.log('Will never printed');

--- a/JavaScript/9-recursive.js
+++ b/JavaScript/9-recursive.js
@@ -18,7 +18,7 @@ class Thenable {
     const onSuccess = this.onSuccess;
     if (onSuccess) {
       const next = onSuccess(value);
-      if (next) {
+      if (next && next.then) {
         next.then(value => {
           this.next.resolve(value);
         });


### PR DESCRIPTION
We may get not a thenable object from callback `onSuccess`. In that case program will fail on string 22 `next.then`
So I added handling for the non-thenable result from callback.

Thank you for great material, Timur!
